### PR TITLE
Refactor UI into Profile and Preferences screens

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".ProfileActivity" />
+        <activity android:name=".PreferencesActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/app_s9/MainActivity.kt
+++ b/app/src/main/java/com/example/app_s9/MainActivity.kt
@@ -2,31 +2,25 @@ package com.example.app_s9
 
 import android.os.Bundle
 import com.google.android.material.button.MaterialButton
-import com.google.android.material.textfield.TextInputEditText
 import android.widget.TextView
-import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.appcompat.widget.SwitchCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import android.content.Intent
+import android.view.Menu
+import android.view.MenuItem
 
 class MainActivity : AppCompatActivity() {
 
     private lateinit var sharedPreferencesHelper: SharedPreferencesHelper
     private lateinit var viewModel: MainViewModel
 
-    private lateinit var editTextName: TextInputEditText
-    private lateinit var editTextAge: TextInputEditText
-    private lateinit var editTextEmail: TextInputEditText
-    private lateinit var buttonSaveProfile: MaterialButton
-    private lateinit var buttonLoadProfile: MaterialButton
     private lateinit var buttonResetCounter: MaterialButton
     private lateinit var textViewOpenCount: TextView
-    private lateinit var switchDarkMode: SwitchCompat
     override fun onCreate(savedInstanceState: Bundle?) {
         sharedPreferencesHelper = SharedPreferencesHelper(this)
         val themeMode = sharedPreferencesHelper.getInt(
@@ -61,31 +55,12 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun initViews() {
-        editTextName = findViewById(R.id.editTextName)
-        editTextAge = findViewById(R.id.editTextAge)
-        editTextEmail = findViewById(R.id.editTextEmail)
-        buttonSaveProfile = findViewById(R.id.buttonSaveProfile)
-        buttonLoadProfile = findViewById(R.id.buttonLoadProfile)
         buttonResetCounter = findViewById(R.id.buttonResetCounter)
         textViewOpenCount = findViewById(R.id.textViewOpenCount)
-        switchDarkMode = findViewById(R.id.switchDarkMode)
-        switchDarkMode.isChecked =
-            viewModel.getThemeMode() == AppCompatDelegate.MODE_NIGHT_YES
     }
 
     private fun setupListeners() {
-        buttonSaveProfile.setOnClickListener { saveProfile() }
-        buttonLoadProfile.setOnClickListener { loadProfile() }
         buttonResetCounter.setOnClickListener { resetCounter() }
-        switchDarkMode.setOnCheckedChangeListener { _, isChecked ->
-            val mode = if (isChecked) {
-                AppCompatDelegate.MODE_NIGHT_YES
-            } else {
-                AppCompatDelegate.MODE_NIGHT_NO
-            }
-            viewModel.saveThemeMode(mode)
-            AppCompatDelegate.setDefaultNightMode(mode)
-        }
     }
 
     private fun updateOpenCount() {
@@ -93,39 +68,28 @@ class MainActivity : AppCompatActivity() {
         textViewOpenCount.text = "Veces abierta: $count"
     }
 
-    private fun saveProfile() {
-        val name = editTextName.text.toString().trim()
-        val ageText = editTextAge.text.toString().trim()
-        val email = editTextEmail.text.toString().trim()
-
-        val age = ageText.toIntOrNull()
-
-        if (name.isEmpty() || age == null || email.isEmpty()) {
-            Toast.makeText(this, "Completa todos los campos", Toast.LENGTH_SHORT).show()
-            return
-        }
-
-        viewModel.saveUserProfile(UserProfile(name, age, email))
-        Toast.makeText(this, "Perfil guardado", Toast.LENGTH_SHORT).show()
-        editTextName.setText("")
-        editTextAge.setText("")
-        editTextEmail.setText("")
-    }
-
-    private fun loadProfile() {
-        val profile = viewModel.loadUserProfile()
-        if (profile == null) {
-            Toast.makeText(this, "No hay perfil guardado", Toast.LENGTH_SHORT).show()
-        } else {
-            editTextName.setText(profile.name)
-            editTextAge.setText(profile.age.toString())
-            editTextEmail.setText(profile.email)
-            Toast.makeText(this, "Perfil cargado", Toast.LENGTH_SHORT).show()
-        }
-    }
 
     private fun resetCounter() {
         viewModel.resetOpenCount()
         textViewOpenCount.text = "Veces abierta: 0"
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.main_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.action_profile -> {
+                startActivity(Intent(this, ProfileActivity::class.java))
+                true
+            }
+            R.id.action_preferences -> {
+                startActivity(Intent(this, PreferencesActivity::class.java))
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
     }
 }

--- a/app/src/main/java/com/example/app_s9/PreferencesActivity.kt
+++ b/app/src/main/java/com/example/app_s9/PreferencesActivity.kt
@@ -1,0 +1,49 @@
+package com.example.app_s9
+
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.appcompat.widget.SwitchCompat
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+class PreferencesActivity : AppCompatActivity() {
+
+    private lateinit var sharedPreferencesHelper: SharedPreferencesHelper
+    private lateinit var viewModel: MainViewModel
+    private lateinit var switchDarkMode: SwitchCompat
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        sharedPreferencesHelper = SharedPreferencesHelper(this)
+        val themeMode = sharedPreferencesHelper.getInt(
+            SharedPreferencesHelper.KEY_THEME_MODE,
+            AppCompatDelegate.MODE_NIGHT_NO
+        )
+        AppCompatDelegate.setDefaultNightMode(themeMode)
+
+        enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_preferences)
+
+        viewModel = ViewModelProvider(this, object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                @Suppress("UNCHECKED_CAST")
+                return MainViewModel(sharedPreferencesHelper) as T
+            }
+        })[MainViewModel::class.java]
+
+        switchDarkMode = findViewById(R.id.switchDarkMode)
+        switchDarkMode.isChecked = viewModel.getThemeMode() == AppCompatDelegate.MODE_NIGHT_YES
+
+        switchDarkMode.setOnCheckedChangeListener { _, isChecked ->
+            val mode = if (isChecked) {
+                AppCompatDelegate.MODE_NIGHT_YES
+            } else {
+                AppCompatDelegate.MODE_NIGHT_NO
+            }
+            viewModel.saveThemeMode(mode)
+            AppCompatDelegate.setDefaultNightMode(mode)
+        }
+    }
+}

--- a/app/src/main/java/com/example/app_s9/ProfileActivity.kt
+++ b/app/src/main/java/com/example/app_s9/ProfileActivity.kt
@@ -1,0 +1,83 @@
+package com.example.app_s9
+
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputEditText
+
+class ProfileActivity : AppCompatActivity() {
+
+    private lateinit var viewModel: MainViewModel
+    private lateinit var sharedPreferencesHelper: SharedPreferencesHelper
+
+    private lateinit var editTextName: TextInputEditText
+    private lateinit var editTextAge: TextInputEditText
+    private lateinit var editTextEmail: TextInputEditText
+    private lateinit var buttonSaveProfile: MaterialButton
+    private lateinit var buttonLoadProfile: MaterialButton
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        sharedPreferencesHelper = SharedPreferencesHelper(this)
+        enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_profile)
+
+        viewModel = ViewModelProvider(this, object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                @Suppress("UNCHECKED_CAST")
+                return MainViewModel(sharedPreferencesHelper) as T
+            }
+        })[MainViewModel::class.java]
+
+        initViews()
+        setupListeners()
+    }
+
+    private fun initViews() {
+        editTextName = findViewById(R.id.editTextName)
+        editTextAge = findViewById(R.id.editTextAge)
+        editTextEmail = findViewById(R.id.editTextEmail)
+        buttonSaveProfile = findViewById(R.id.buttonSaveProfile)
+        buttonLoadProfile = findViewById(R.id.buttonLoadProfile)
+    }
+
+    private fun setupListeners() {
+        buttonSaveProfile.setOnClickListener { saveProfile() }
+        buttonLoadProfile.setOnClickListener { loadProfile() }
+    }
+
+    private fun saveProfile() {
+        val name = editTextName.text.toString().trim()
+        val ageText = editTextAge.text.toString().trim()
+        val email = editTextEmail.text.toString().trim()
+
+        val age = ageText.toIntOrNull()
+
+        if (name.isEmpty() || age == null || email.isEmpty()) {
+            Toast.makeText(this, "Completa todos los campos", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        viewModel.saveUserProfile(UserProfile(name, age, email))
+        Toast.makeText(this, "Perfil guardado", Toast.LENGTH_SHORT).show()
+        editTextName.setText("")
+        editTextAge.setText("")
+        editTextEmail.setText("")
+    }
+
+    private fun loadProfile() {
+        val profile = viewModel.loadUserProfile()
+        if (profile == null) {
+            Toast.makeText(this, "No hay perfil guardado", Toast.LENGTH_SHORT).show()
+        } else {
+            editTextName.setText(profile.name)
+            editTextAge.setText(profile.age.toString())
+            editTextEmail.setText(profile.email)
+            Toast.makeText(this, "Perfil cargado", Toast.LENGTH_SHORT).show()
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -31,63 +31,6 @@
             android:text="Reset Contador"
             android:layout_marginBottom="24dp" />
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editTextName"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="Nombre" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editTextAge"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="Edad"
-                android:inputType="number" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editTextEmail"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="Email"
-                android:inputType="textEmailAddress" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/buttonSaveProfile"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Guardar"
-            android:layout_marginBottom="16dp" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/buttonLoadProfile"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Cargar"
-            android:layout_marginBottom="16dp" />
-
-        <androidx.appcompat.widget.SwitchCompat
-            android:id="@+id/switchDarkMode"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Modo Oscuro" />
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp"
+    tools:context=".PreferencesActivity">
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/switchDarkMode"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Modo Oscuro" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp"
+    tools:context=".ProfileActivity">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editTextName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Nombre" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editTextAge"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Edad"
+            android:inputType="number" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editTextEmail"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Email"
+            android:inputType="textEmailAddress" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonSaveProfile"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Guardar"
+        android:layout_marginBottom="16dp" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonLoadProfile"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Cargar"
+        android:layout_marginBottom="16dp" />
+
+</LinearLayout>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_profile"
+        android:title="Perfil" />
+    <item
+        android:id="@+id/action_preferences"
+        android:title="Preferencias" />
+</menu>


### PR DESCRIPTION
## Summary
- move profile and dark mode options out of MainActivity
- add `ProfileActivity` and `PreferencesActivity`
- trim `activity_main.xml` to only show the open-count section
- provide menu actions to open the new activities

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685346fa12d883298bee8e54685ff651