### PR TITLE
Mejoras de Perfil y contador

### DIFF
--- a/app/src/main/java/com/example/app_s9/MainActivity.kt
+++ b/app/src/main/java/com/example/app_s9/MainActivity.kt
@@ -65,13 +65,13 @@ class MainActivity : AppCompatActivity() {
 
     private fun updateOpenCount() {
         val count = viewModel.incrementOpenCount()
-        textViewOpenCount.text = "Veces abierta: $count"
+        textViewOpenCount.text = count.toString()
     }
 
 
     private fun resetCounter() {
         viewModel.resetOpenCount()
-        textViewOpenCount.text = "Veces abierta: 0"
+        textViewOpenCount.text = "0"
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/java/com/example/app_s9/ProfileActivity.kt
+++ b/app/src/main/java/com/example/app_s9/ProfileActivity.kt
@@ -20,7 +20,7 @@ class ProfileActivity : AppCompatActivity() {
     private lateinit var editTextAge: TextInputEditText
     private lateinit var editTextEmail: TextInputEditText
     private lateinit var buttonSaveProfile: MaterialButton
-    private lateinit var buttonLoadProfile: MaterialButton
+    private lateinit var buttonClearFields: MaterialButton
 
     override fun onCreate(savedInstanceState: Bundle?) {
         sharedPreferencesHelper = SharedPreferencesHelper(this)
@@ -43,6 +43,7 @@ class ProfileActivity : AppCompatActivity() {
         })[MainViewModel::class.java]
 
         initViews()
+        loadProfile()
         setupListeners()
     }
 
@@ -61,12 +62,12 @@ class ProfileActivity : AppCompatActivity() {
         editTextAge = findViewById(R.id.editTextAge)
         editTextEmail = findViewById(R.id.editTextEmail)
         buttonSaveProfile = findViewById(R.id.buttonSaveProfile)
-        buttonLoadProfile = findViewById(R.id.buttonLoadProfile)
+        buttonClearFields = findViewById(R.id.buttonClearFields)
     }
 
     private fun setupListeners() {
         buttonSaveProfile.setOnClickListener { saveProfile() }
-        buttonLoadProfile.setOnClickListener { loadProfile() }
+        buttonClearFields.setOnClickListener { clearFields() }
     }
 
     private fun saveProfile() {
@@ -90,13 +91,16 @@ class ProfileActivity : AppCompatActivity() {
 
     private fun loadProfile() {
         val profile = viewModel.loadUserProfile()
-        if (profile == null) {
-            Toast.makeText(this, "No hay perfil guardado", Toast.LENGTH_SHORT).show()
-        } else {
+        if (profile != null) {
             editTextName.setText(profile.name)
             editTextAge.setText(profile.age.toString())
             editTextEmail.setText(profile.email)
-            Toast.makeText(this, "Perfil cargado", Toast.LENGTH_SHORT).show()
         }
+    }
+
+    private fun clearFields() {
+        editTextName.setText("")
+        editTextAge.setText("")
+        editTextEmail.setText("")
     }
 }

--- a/app/src/main/res/drawable/ic_user_circle.xml
+++ b/app/src/main/res/drawable/ic_user_circle.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="120dp"
+    android:height="120dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="@android:color/black"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="@android:color/black"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M12 10m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0"/>
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="@android:color/black"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M6.168 18.849a4 4 0 0 1 3.832 -2.849h4a4 4 0 0 1 3.834 2.855"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,6 +10,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:gravity="center"
         android:orientation="vertical"
         android:padding="16dp"
         app:layout_constraintTop_toTopOf="parent"
@@ -18,10 +19,18 @@
         app:layout_constraintEnd_toEndOf="parent">
 
         <TextView
+            android:id="@+id/textViewOpenLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Veces abierta"
+            android:layout_marginBottom="4dp" />
+
+        <TextView
             android:id="@+id/textViewOpenCount"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Veces abierta: 0"
+            android:text="0"
+            android:textSize="48sp"
             android:layout_marginBottom="16dp" />
 
         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -17,6 +17,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 
+        <ImageView
+            android:id="@+id/imageViewAvatar"
+            android:layout_width="120dp"
+            android:layout_height="120dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginBottom="24dp"
+            android:src="@drawable/ic_user_circle" />
+
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -63,10 +71,10 @@
             android:layout_marginBottom="16dp" />
 
         <com.google.android.material.button.MaterialButton
-            android:id="@+id/buttonLoadProfile"
+            android:id="@+id/buttonClearFields"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Cargar"
+            android:text="Limpiar"
             android:layout_marginBottom="16dp" />
 
     </LinearLayout>


### PR DESCRIPTION
## Summary
- auto cargar datos del perfil
- agregar icono de usuario grande en la pantalla de perfil
- limpiar inputs desde el botón "Limpiar"
- reorganizar contador principal para mostrar número grande

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68539490df98832987b1b7146d816930