### PR TITLE
Add About screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
         </activity>
         <activity android:name=".ProfileActivity" />
         <activity android:name=".PreferencesActivity" />
+        <activity android:name=".AboutActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/app_s9/AboutActivity.kt
+++ b/app/src/main/java/com/example/app_s9/AboutActivity.kt
@@ -1,0 +1,63 @@
+package com.example.app_s9
+
+import android.os.Bundle
+import android.util.Base64
+import android.widget.TextView
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+class AboutActivity : AppCompatActivity() {
+
+    private lateinit var viewModel: MainViewModel
+    private lateinit var sharedPreferencesHelper: SharedPreferencesHelper
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        sharedPreferencesHelper = SharedPreferencesHelper(this)
+        val themeMode = sharedPreferencesHelper.getInt(
+            SharedPreferencesHelper.KEY_THEME_MODE,
+            AppCompatDelegate.MODE_NIGHT_NO
+        )
+        AppCompatDelegate.setDefaultNightMode(themeMode)
+
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContentView(R.layout.activity_about)
+        supportActionBar?.title = getString(R.string.title_about)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.aboutRoot)) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+
+        viewModel = ViewModelProvider(this, object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                @Suppress("UNCHECKED_CAST")
+                return MainViewModel(sharedPreferencesHelper) as T
+            }
+        })[MainViewModel::class.java]
+
+        val developerNameEncoded = getString(R.string.developer_name_encoded)
+        val developerNickEncoded = getString(R.string.developer_nick_encoded)
+        val developerName = String(Base64.decode(developerNameEncoded, Base64.DEFAULT))
+        val developerNick = String(Base64.decode(developerNickEncoded, Base64.DEFAULT))
+
+        findViewById<TextView>(R.id.textViewDeveloper).text = getString(R.string.about_developer, developerName)
+        findViewById<TextView>(R.id.textViewCopyright).text = getString(R.string.about_copyright, developerNick)
+    }
+
+    override fun onOptionsItemSelected(item: android.view.MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                finish()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+}

--- a/app/src/main/java/com/example/app_s9/MainActivity.kt
+++ b/app/src/main/java/com/example/app_s9/MainActivity.kt
@@ -89,6 +89,10 @@ class MainActivity : AppCompatActivity() {
                 startActivity(Intent(this, PreferencesActivity::class.java))
                 true
             }
+            R.id.action_about -> {
+                startActivity(Intent(this, AboutActivity::class.java))
+                true
+            }
             else -> super.onOptionsItemSelected(item)
         }
     }

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/aboutRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".AboutActivity">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp"
+        android:gravity="center"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:id="@+id/textViewAppName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/about_app_name"
+            android:textStyle="bold"
+            android:textSize="20sp"
+            android:layout_marginBottom="4dp" />
+
+        <TextView
+            android:id="@+id/textViewVersion"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/about_version"
+            android:layout_marginBottom="16dp" />
+
+        <TextView
+            android:id="@+id/textViewDescription"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/about_description"
+            android:textAlignment="center"
+            android:layout_marginBottom="24dp" />
+
+        <TextView
+            android:id="@+id/textViewDeveloper"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAlignment="center"
+            android:layout_marginBottom="4dp" />
+
+        <TextView
+            android:id="@+id/textViewCopyright"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAlignment="center" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -6,4 +6,7 @@
     <item
         android:id="@+id/action_preferences"
         android:title="Preferencias" />
+    <item
+        android:id="@+id/action_about"
+        android:title="Acerca de" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,12 @@
     <string name="app_name">app_s9</string>
     <string name="title_preferences">Preferencias</string>
     <string name="title_profile">Perfil</string>
+    <string name="title_about">Acerca de</string>
+    <string name="about_app_name">App S9 - SharedPreferences</string>
+    <string name="about_version">Versión 1.0</string>
+    <string name="about_description">Aplicación Android de ejemplo que demuestra el uso básico de SharedPreferences para almacenamiento persistente de datos.</string>
+    <string name="about_developer">Desarrollado por %1$s</string>
+    <string name="about_copyright">Copyright © 2025 %1$s</string>
+    <string name="developer_name_encoded">Sm9obiBEb2U=</string>
+    <string name="developer_nick_encoded">SkREZXY=</string>
 </resources>


### PR DESCRIPTION
## Summary
- add an About screen to show info about the project
- show base64-decoded developer data on the About screen
- add About option to menu and hook it in MainActivity

## Testing
- `./gradlew test` *(fails: Unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6853a6c3f79083299852975a293b82ec